### PR TITLE
stage4: fix wrong relative path to clownlzss submodule in misc.sh

### DIFF
--- a/stage4/misc.sh
+++ b/stage4/misc.sh
@@ -12,7 +12,7 @@ cp -r bin/install/* $PREFIX/m68k-elf
 
 # Install host build of ClownLZSS, for its compression utility.
 mkdir -p bin/clownlzss-host
-cmake -B bin/clownlzss-host ../../clownlzss \
+cmake -B bin/clownlzss-host clownlzss \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON \
     -DCMAKE_POLICY_DEFAULT_CMP0069=NEW \
@@ -22,7 +22,7 @@ cmake --install bin/clownlzss-host --config Release --prefix $PREFIX --strip
 
 # Install target build of ClownLZSS, for its decompression libraries.
 mkdir -p bin/clownlzss-target
-cmake -B bin/clownlzss-target ../../clownlzss \
+cmake -B bin/clownlzss-target clownlzss \
     --toolchain=$PREFIX/toolchain.cmake \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON \


### PR DESCRIPTION
`misc.sh` references the `clownlzss` submodule as `../../clownlzss` when configuring both the host and target CMake builds, but per `.gitmodules` the submodule actually lives at `stage4/clownlzss` — i.e. one directory below `misc.sh`, not two directories above it.

This makes the path resolve outside the repository entirely (`<repo>/../clownlzss`), so `cmake -B bin/clownlzss-host ../../clownlzss` fails with "No such file or directory" as soon as the submodule is actually checked out.

This was introduced in d52b8e8 ("Install ClownLZSS the proper way"), which added these `cmake -B` calls with the wrong relative path from the start.

Fix: use the correct relative path (`clownlzss`) for both the host and target builds.

Tested by running `stage4/misc.sh` after stages 1-3 on Ubuntu 24.04 — both `clownlzss-host` and `clownlzss-target` now configure and build successfully.